### PR TITLE
Clarify language on affiliation

### DIFF
--- a/text/3392-leadership-council.md
+++ b/text/3392-leadership-council.md
@@ -199,7 +199,7 @@ If the Council and top-level teams cannot agree on appropriate term end-date cha
 
 ## Limits on representatives from a single company/entity
 
-Council representatives must not disproportionately come from any one company, legal entity, or closely related set of legal entities, to avoid impropriety or the appearance of impropriety. If the Council has 5 or fewer representatives, no more than 1 representative may have the same affiliation; if the Council has 6 or more representatives, no more than 2 representatives may have the same affiliation.
+Council representatives must not disproportionately come from any one company, legal entity, or closely related set of legal entities, to avoid impropriety or the appearance of impropriety. If the Council has 5 or fewer representatives, no more than 1 representative may have any given affiliation; if the Council has 6 or more representatives, no more than 2 representatives may have any given affiliation.
 
 Closely related legal entities include branches/divisions/subsidiaries of the same entity, entities connected through substantial ownership interests, or similar. The Council may make a judgment call in unusual cases, taking care to avoid conflicts of interest in that decision.
 


### PR DESCRIPTION
Phrases like "no more than 2 representatives may have the same
affiliation" could be ambiguous: they could also mean "no more than 2
representatives may share an affiliation with any other representative",
implying that you can't have more than one such pair on the Council.

Rephrase to "may share any given affiliation" for clarity.

Checkboxes:
- [x] @Mark-Simulacrum
- [x] @yaahc
- [x] @joshtriplett
- [x] @technetos
- [x] @khionu
- [x] @jntrnr
- [x] @rylev
